### PR TITLE
Refactor: 게시글 생성 transaction 방식 수정

### DIFF
--- a/src/board/board.service.ts
+++ b/src/board/board.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@nestjs/common';
-import { board, category, PrismaClient } from '@prisma/client';
+import { board, PrismaClient } from '@prisma/client';
 import { CreateBoardDto } from './dto/create-board.dto';
 import { SelectBoardDto } from './dto/select-board.dto';
 import { BoardRepository } from './repository/board.repository';


### PR DESCRIPTION
prisma 타입 에러 해결하면서 방식을 바꿔보고자 한번 수정해봤는데 어떻게 생각하시나요?

게시글 생성 및 카테고리들 생성이 완료된 후 categories_on_board 저장될 때 에러가 발생하면 DB에 가비지 값이 남기는 합니다만 에러가 날 수 있을까요..? 
에러 발생하는 케이스가 게시글과 카테고리들이 생성되고나서 DB 연결이 끊기면 에러가 발생할 수 있겠네요. 근데 확률이 너무나 낮은지라..🤯

코드만 한번 봐주시고 코멘트 남겨주세요! 타입 명시하지 않은 것은 정상적으로 추론되기 때문입니다~